### PR TITLE
Added the possibility to define the text option as a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ Channel to send message to. Can be a public channel, private group or IM channel
 
 
 #### text
-Type: `String`
+Type: `String` or `Function`
 
 Text of the message to send. Messages are formatted as described in the [formatting spec](https://api.slack.com/docs/formatting).
+You can also define the text as function so you're able to build the text at run time.
 
 
 #### username
@@ -74,6 +75,24 @@ slack_notifier: {
 }
 ```
 
+alternatively you can define the text as a function:
+
+```js
+slack_notifier: {
+  notification: {
+    options: {
+      token: 'EXAMPLE-TOKEN',
+      channel: '#notifications',
+      text: function(grunt, options) {
+          var currentId = grunt.config.get('customerId'),
+              customerName = customers.getCustomerName(currentId);
+          return 'Deployed customer ' + customerName + ' with customer ID ' + currentId;
+      },
+      username: 'Grunt.js'
+    }
+  }
+}
+```
 
 ## Release history
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-slack-notifier",
   "description": "Slack notifications from grunt",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "author": "Germán Robledo <germanrcuriel@gmail.com>",
   "dependencies": {
     "slack-api-client": "^0.0.2"

--- a/src/slack_notifier.coffee
+++ b/src/slack_notifier.coffee
@@ -9,7 +9,7 @@ module.exports = (grunt) ->
 
     slack.api.chat.postMessage
       channel: options.channel
-      text: options.text
+      text: if typeof options.text == 'function' then options.text(grunt, options) else options.text
       username: options.username
     , (err, res) ->
       grunt.fatal err if err

--- a/src/slack_notifier.coffee
+++ b/src/slack_notifier.coffee
@@ -9,7 +9,7 @@ module.exports = (grunt) ->
 
     slack.api.chat.postMessage
       channel: options.channel
-      text: if typeof options.text == 'function' then options.text(grunt, options) else options.text
+      text: if typeof options.text is 'function' then options.text(grunt, options) else options.text
       username: options.username
     , (err, res) ->
       grunt.fatal err if err


### PR DESCRIPTION
Added the possibility to define the text option as a function so you can compile your slack message at run time. With this changes you can define text like this:

``` javascript
slack_notifier: {
  notification: {
    options: {
      token: 'EXAMPLE-TOKEN',
      channel: '#notifications',
      text: function(grunt, options) {
        var currentId = grunt.config.get('customerId'),
        customerName = customers.getCustomerName(currentId);
        return 'Deployed customer ' + customerName + ' with customer ID ' + currentId;
      },
      username: 'Grunt.js'
    }
  }
}
```
