### PR TITLE
Added additional configuration option of postMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ grunt.loadNpmTasks('grunt-slack-notifier');
 *This plugin was designed to work with Grunt 0.4.x. If you're still using grunt v0.3.x it's strongly recommended that [you upgrade](http://gruntjs.com/upgrading-from-0.3-to-0.4), but in case you can't please use [v0.3.2](https://github.com/gruntjs/grunt-contrib-copy/tree/grunt-0.3-stable).*
 
 
-## "slack_notifier" task
+## 'slack_notifier' task
 _Run this task with the `grunt slack_notifier` command._
 
 Task targets, files and options may be specified according to the grunt [Configuring tasks](http://gruntjs.com/configuring-tasks) guide.
@@ -59,6 +59,54 @@ Default: `Grunt.js`
 
 Name of bot.
 
+#### as_user
+Type: `Boolean`
+Default: `false`
+
+Set to true to post the message as the authenticated user (based on token). In that case `username`, `icon_url` and `icon_emoji` settings will be ignored
+
+#### parse
+Type: `String`
+Default: `full`
+
+Set to `none` to let Slack handle the message as plain text without escaping entities
+
+#### link_names
+Type: `Boolean`
+Default: `false`
+
+Set to true if you want references to private/public channels or users to be automatically linked
+
+#### attachments
+Type: `Array`
+Default: `null`
+
+An list of attachements for your message. See https://api.slack.com/docs/attachments#message_formatting
+
+#### unfurl_links
+Type: `Boolean`
+Default: `true`
+
+See https://api.slack.com/docs/unfurling
+
+#### unfurl_media
+Type: `Boolean`
+Default: `false`
+
+See https://api.slack.com/docs/unfurling
+
+#### icon_url
+Type: `String`
+Default: `null`
+
+Define an image to be used as profile picture for your slackBot message
+
+#### icon_emoji
+Type: `String`
+Default: `null`
+
+Alternatively define a emoji as profile picture. This overwrites `icon_url`
+
 
 ### Usage Examples
 
@@ -69,7 +117,36 @@ slack_notifier: {
       token: 'EXAMPLE-TOKEN',
       channel: '#notifications',
       text: 'Deploying to production...',
-      username: 'Grunt.js'
+      username: 'Grunt.js',
+      as_user: false,
+      parse: 'full',
+      link_names: true,
+      attachments: [
+        {
+          'fallback': 'Required plain-text summary of the attachment.',
+          'color': '#36a64f',
+          'pretext': 'Optional text that appears above the attachment block',
+          'author_name': 'Bobby Tables',
+          'author_link': 'http://flickr.com/bobby/',
+          'author_icon': 'http://flickr.com/icons/bobby.jpg',
+          'title': 'Slack API Documentation',
+          'title_link': 'https://api.slack.com/',
+          'text': 'Optional text that appears within the attachment',
+          'fields': [
+            {
+              'title': 'Priority',
+              'value': 'High',
+              'short': false
+            }
+          ],
+          'image_url': 'http://my-website.com/path/to/image.jpg',
+          'thumb_url': 'http://example.com/path/to/thumb.png'
+        }
+      ],
+      unfurl_links: true,
+      unfurl_media: true,
+      icon_url: 'http://my-website.com/path/to/image.jpg',
+      icon_emoji: ':stuck_out_tongue_winking_eye:'
     }
   }
 }
@@ -89,6 +166,7 @@ slack_notifier: {
           return 'Deployed customer ' + customerName + ' with customer ID ' + currentId;
       },
       username: 'Grunt.js'
+      ...
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ Channel to send message to. Can be a public channel, private group or IM channel
 
 
 #### text
-Type: `String`
+Type: `String` or `Function`
 
 Text of the message to send. Messages are formatted as described in the [formatting spec](https://api.slack.com/docs/formatting).
+You can also define the text as function so you're able to build the text at run time.
 
 
 #### username
@@ -74,6 +75,24 @@ slack_notifier: {
 }
 ```
 
+alternatively you can define the text as a function:
+
+```js
+slack_notifier: {
+  notification: {
+    options: {
+      token: 'EXAMPLE-TOKEN',
+      channel: '#notifications',
+      text: function(grunt, options) {
+          var currentId = grunt.config.get('customerId'),
+              customerName = customers.getCustomerName(currentId);
+          return 'Deployed customer ' + customerName + ' with customer ID ' + currentId;
+      },
+      username: 'Grunt.js'
+    }
+  }
+}
+```
 
 ## Release history
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-slack-notifier",
   "description": "Slack notifications from grunt",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "author": "Germán Robledo <germanrcuriel@gmail.com>",
   "dependencies": {
     "slack-api-client": "^0.0.2"

--- a/src/slack_notifier.coffee
+++ b/src/slack_notifier.coffee
@@ -9,7 +9,7 @@ module.exports = (grunt) ->
 
     slack.api.chat.postMessage
       channel: options.channel
-      text: options.text
+      text: if typeof options.text == 'function' then options.text(grunt, options) else options.text
       username: options.username
     , (err, res) ->
       grunt.fatal err if err

--- a/src/slack_notifier.coffee
+++ b/src/slack_notifier.coffee
@@ -2,6 +2,54 @@ SlackClient = require 'slack-api-client'
 
 module.exports = (grunt) ->
 
+  ###*
+  * @typedef {Object} field
+  * @property {String} title Shown as a bold heading above the value text. It cannot contain markup and will be escaped for you.
+  * @property {String} value The text value of the field. It may contain standard message markup and must be escaped as normal. May be multi-line.
+  * @property {Boolean} short An optional flag indicating whether the value is short enough to be displayed side-by-side with other values.
+  ###
+
+  ###*
+  * @description Definition of the structured message attachment
+  * @see https://api.slack.com/docs/attachments
+  * @typedef {Object} attachment
+  * @property {String} fallback A plain-text summary of the attachment. This text will be used in clients that don't show formatted text (eg. IRC, mobile notifications) and should not contain any markup.
+  * @property {String} text This is the main text in a message attachment, and can contain standard message markup. The content will automatically collapse if it contains 700+ characters or 5+ linebreaks, and will display a "Show more..." link to expand the content.
+  * @property {String} title The title is displayed as larger, bold text near the top of a message attachment.
+  * @property {String} [title_link] By passing a valid URL in the title_link parameter (optional), the title text will be hyperlinked.
+  * @property {String} [color] An optional value that can either be one of good, warning, danger, or any hex color code (eg. #439FE0). This value is used to color the border along the left side of the message attachment.
+  * @property {String} [pretext] This is optional text that appears above the message attachment block.
+  * @property {String} [author_name] Small text used to display the author's name.
+  * @property {String} [author_link] A valid URL that will hyperlink the author_name text mentioned above. Will only work if author_name is present.
+  * @property {String} [author_icon] A valid URL that displays a small 16x16px image to the left of the author_name text. Will only work if author_name is present.
+  * @property {Array.<field>} [fields] Fields are defined as an array, and hashes contained within it will be displayed in a table inside the message attachment.
+  * @property {String} [image_url] A valid URL to an image file that will be displayed inside a message attachment. We currently support the following formats: GIF, JPEG, PNG, and BMP. Large images will be resized to a maximum width of 400px or a maximum height of 500px, while still maintaining the original aspect ratio.
+  * @property {String} [thumb_url] A valid URL to an image file that will be displayed as a thumbnail on the right side of a message attachment. We currently support the following formats: GIF, JPEG, PNG, and BMP. The thumbnail's longest dimension will be scaled down to 75px while maintaining the aspect ratio of the image. The filesize of the image must also be less than 500 KB.
+  ###
+
+  ###*
+  * @description Options Object for configuring the postMessage call to Slack
+  * @see https://api.slack.com/methods/chat.postMessage
+  * @typedef {Object} options
+  * @property {String} token Authentication token
+  * @property {String} channel Channel, private group, or IM channel to send message to. Can be an encoded ID, or a name. See below for more details.
+  * @property {String} text Text of the message to send. See below for an explanation of formatting.
+  * @property {String} username Name of bot.
+  * @property {Boolean} [as_user=false] Pass true to post the message as the authed user, instead of as a bot.
+  * @property {String} [parse='full'] Change how messages are treated.
+  * @property {Boolean} [link_names=false] Find and link channel names and usernames.
+  * @property {Array.<attachment>} [attachments] Structured message attachments.
+  * @property {Boolean} [unfurl_links] Pass true to enable unfurling of primarily text-based content.
+  * @property {Boolean} [unfurl_media] Pass false to disable unfurling of media content.
+  * @property {String} [icon_url] URL to an image to use as the icon for this message
+  * @property {String} [icon_emoji] emoji to use as the icon for this message. Overrides icon_url.
+  ###
+
+  ###*
+  * @description Sends a message to Slack using the Slack API client
+  * @param {Object} options An object containing the configuration parameters for postMessage
+  * @param {Function} cb Callback function called when the postMessage call finished.
+  ###
   sendMessage = (options, cb) ->
     slack = new SlackClient options.token
 
@@ -11,13 +59,20 @@ module.exports = (grunt) ->
       channel: options.channel
       text: if typeof options.text is 'function' then options.text(grunt, options) else options.text
       username: options.username
+      as_user: options.as_user || null,
+      parse: options.parse || null,
+      link_names: options.link_names || null
+      attachments: if grunt.util.kindOf(options.attachments) is 'array' then JSON.stringify(options.attachments) else null
+      unfurl_links: options.unfurl_links || null
+      unfurl_media: options.unfurl_media || null
+      icon_url: options.icon_url || null
+      icon_emoji: options.icon_emoji || null
     , (err, res) ->
       grunt.fatal err if err
       grunt.log.ok 'Notification sent!'
       cb()
 
   grunt.registerMultiTask 'slack_notifier', 'Send a message to a Slack channel', ->
-
     done = @async()
     error = false
 

--- a/src/slack_notifier.coffee
+++ b/src/slack_notifier.coffee
@@ -47,7 +47,7 @@ module.exports = (grunt) ->
 
   ###*
   * @description Sends a message to Slack using the Slack API client
-  * @param {Object} options An object containing the configuration parameters for postMessage
+  * @param {options} options An object containing the configuration parameters for postMessage
   * @param {Function} cb Callback function called when the postMessage call finished.
   ###
   sendMessage = (options, cb) ->

--- a/src/slack_notifier.coffee
+++ b/src/slack_notifier.coffee
@@ -59,14 +59,14 @@ module.exports = (grunt) ->
       channel: options.channel
       text: if typeof options.text is 'function' then options.text(grunt, options) else options.text
       username: options.username
-      as_user: options.as_user || null,
-      parse: options.parse || null,
-      link_names: options.link_names || null
+      as_user: options.as_user,
+      parse: options.parse,
+      link_names: options.link_names
       attachments: if grunt.util.kindOf(options.attachments) is 'array' then JSON.stringify(options.attachments) else null
-      unfurl_links: options.unfurl_links || null
-      unfurl_media: options.unfurl_media || null
-      icon_url: options.icon_url || null
-      icon_emoji: options.icon_emoji || null
+      unfurl_links: options.unfurl_links
+      unfurl_media: options.unfurl_media
+      icon_url: options.icon_url
+      icon_emoji: options.icon_emoji
     , (err, res) ->
       grunt.fatal err if err
       grunt.log.ok 'Notification sent!'

--- a/src/slack_notifier.coffee
+++ b/src/slack_notifier.coffee
@@ -9,7 +9,7 @@ module.exports = (grunt) ->
 
     slack.api.chat.postMessage
       channel: options.channel
-      text: if typeof options.text == 'function' then options.text(grunt, options) else options.text
+      text: if typeof options.text is 'function' then options.text(grunt, options) else options.text
       username: options.username
     , (err, res) ->
       grunt.fatal err if err

--- a/src/slack_notifier.coffee
+++ b/src/slack_notifier.coffee
@@ -57,7 +57,7 @@ module.exports = (grunt) ->
 
     slack.api.chat.postMessage
       channel: options.channel
-      text: if typeof options.text is 'function' then options.text(grunt, options) else options.text
+      text: if grunt.util.kindOf(options.text) is 'function' then options.text(grunt, options) else options.text
       username: options.username
       as_user: options.as_user,
       parse: options.parse,


### PR DESCRIPTION
I added all available configuration options to the task that are available for Slacks postMessage API call. I also updated the README file to reflect the changes. JSDoc comment have been added to the script. 

The new configuration options are:
as_user, parse, link_names, attachments, unfurl_links, unfurl_media, con_url and con_emoji

This pull request is based on my prior PR #1 therefor I would recommend to pull #1 first.
